### PR TITLE
fix: update file paths in Vite config and enhance static file copying

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
-import { copyFileSync, mkdirSync } from 'fs';
+import { copyFileSync, mkdirSync, existsSync } from 'fs';
 
 export default defineConfig({
   build: {
@@ -9,8 +9,8 @@ export default defineConfig({
       input: {
         background: resolve(__dirname, 'src/background/background.ts'),
         content: resolve(__dirname, 'src/content/content.ts'),
-        popup: resolve(__dirname, 'src/popup/popup.html'),
-        options: resolve(__dirname, 'src/options/options.html')
+        popup: resolve(__dirname, 'src/popup/popup.ts'),
+        options: resolve(__dirname, 'src/options/options.ts')
       },
       output: {
         entryFileNames: '[name].js',
@@ -22,17 +22,25 @@ export default defineConfig({
   },
   plugins: [
     {
-      name: 'copy-manifest',
+      name: 'copy-static-files',
       writeBundle() {
         // manifest.jsonをコピー
         copyFileSync('manifest.json', 'dist/manifest.json');
         
         // アイコンをコピー
         mkdirSync('dist/assets/icons', { recursive: true });
-        copyFileSync('code-review-extension-icon.jpg', 'dist/assets/icons/icon.jpg');
+        copyFileSync('assets/icons/icon.jpg', 'dist/assets/icons/icon.jpg');
         
         // スタイルシートをコピー
         copyFileSync('src/content/styles.css', 'dist/styles.css');
+        
+        // HTMLファイルをコピー
+        copyFileSync('src/popup/popup.html', 'dist/popup.html');
+        copyFileSync('src/options/options.html', 'dist/options.html');
+        
+        // CSSファイルをコピー
+        copyFileSync('src/popup/popup.css', 'dist/popup.css');
+        copyFileSync('src/options/options.css', 'dist/options.css');
       }
     }
   ]


### PR DESCRIPTION
## What is the current behavior?
Currently, the Vite build configuration has incorrect file paths for popup and options entries, pointing directly to HTML files instead of the TypeScript entry points. Additionally, the static file copying process is incomplete, missing HTML and CSS files necessary for the extension UI to function properly.

## What is the new behavior?
- Fixed entry points in Vite config to properly point to TypeScript files (`popup.ts` and `options.ts`) instead of HTML files
- Enhanced the static file copying plugin to:
  - Copy HTML files (popup.html and options.html) to the dist folder
  - Copy CSS files (popup.css and options.css) to the dist folder
  - Use the correct path for icon file from the assets directory
- Renamed plugin to 'copy-static-files' to better reflect its broader functionality
- Added `existsSync` import from 'fs' to support potential future file existence checks
