### PR TITLE
複数AIプロバイダー対応と最新モデルサポートの実装

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -70,7 +70,8 @@ body {
 }
 
 .form-input,
-.form-textarea {
+.form-textarea,
+.form-select {
   width: 100%;
   padding: 8px 12px;
   font-size: 14px;
@@ -83,10 +84,20 @@ body {
 }
 
 .form-input:focus,
-.form-textarea:focus {
+.form-textarea:focus,
+.form-select:focus {
   outline: none;
   border-color: #0969da;
   box-shadow: 0 0 0 3px rgba(9, 105, 218, 0.1);
+}
+
+.form-select {
+  cursor: pointer;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%23666" d="M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 40px;
+  appearance: none;
 }
 
 .form-textarea {
@@ -107,6 +118,20 @@ body {
 
 .form-help a:hover {
   text-decoration: underline;
+}
+
+/* プロバイダー設定 */
+.provider-config {
+  margin-top: 20px;
+  padding: 16px;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+  border-left: 4px solid #0969da;
+  transition: opacity 0.3s ease;
+}
+
+.provider-config.hidden {
+  display: none;
 }
 
 /* ステップ設定 */
@@ -267,16 +292,27 @@ body {
   }
 
   .form-input,
-  .form-textarea {
+  .form-textarea,
+  .form-select {
     color: #c9d1d9;
     background-color: #0d1117;
     border-color: #30363d;
   }
 
   .form-input:focus,
-  .form-textarea:focus {
+  .form-textarea:focus,
+  .form-select:focus {
     border-color: #58a6ff;
     box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+  }
+
+  .form-select {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%23c9d1d9" d="M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z"/></svg>');
+  }
+
+  .provider-config {
+    background-color: #161b22;
+    border-left-color: #58a6ff;
   }
 
   .form-help {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -14,21 +14,128 @@
     </header>
 
     <main class="options-content">
-      <!-- APIキー設定 -->
+      <!-- AIプロバイダー設定 -->
       <section class="settings-section">
-        <h2>OpenAI API設定</h2>
+        <h2>AIプロバイダー設定</h2>
+        
+        <!-- プロバイダー選択 -->
         <div class="form-group">
-          <label for="apiKey">APIキー</label>
-          <input 
-            type="password" 
-            id="apiKey" 
-            class="form-input" 
-            placeholder="sk-..."
-          />
-          <p class="form-help">
-            OpenAI APIキーを入力してください。
-            <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">APIキーの取得はこちら</a>
-          </p>
+          <label for="aiProvider">AIプロバイダー</label>
+          <select id="aiProvider" class="form-select">
+            <option value="openai">OpenAI (GPT-4o, O1)</option>
+            <option value="claude">Claude (Sonnet 4, 3.7)</option>
+            <option value="gemini">Google Gemini (2.5, 2.0)</option>
+            <option value="openai-compatible">OpenAI Compatible</option>
+          </select>
+          <p class="form-help">使用するAIプロバイダーを選択してください</p>
+        </div>
+
+        <!-- OpenAI設定 -->
+        <div id="openai-config" class="provider-config">
+          <div class="form-group">
+            <label for="openai-apiKey">OpenAI APIキー</label>
+            <input 
+              type="password" 
+              id="openai-apiKey" 
+              class="form-input" 
+              placeholder="sk-..."
+            />
+            <p class="form-help">
+              <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">APIキーの取得はこちら</a>
+            </p>
+          </div>
+          <div class="form-group">
+            <label for="openai-model">モデル</label>
+            <select id="openai-model" class="form-select">
+              <option value="gpt-4o">GPT-4o</option>
+              <option value="o1">O1</option>
+              <option value="o1-mini">O1 Mini</option>
+              <option value="gpt-4o-mini">GPT-4o Mini</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Claude設定 -->
+        <div id="claude-config" class="provider-config" style="display: none;">
+          <div class="form-group">
+            <label for="claude-apiKey">Claude APIキー</label>
+            <input 
+              type="password" 
+              id="claude-apiKey" 
+              class="form-input" 
+              placeholder="sk-ant-..."
+            />
+            <p class="form-help">
+              <a href="https://console.anthropic.com/" target="_blank" rel="noopener">APIキーの取得はこちら</a>
+            </p>
+          </div>
+          <div class="form-group">
+            <label for="claude-model">モデル</label>
+            <select id="claude-model" class="form-select">
+              <option value="claude-4-20250514">Claude 4 (Sonnet 4)</option>
+              <option value="claude-3-7-sonnet-20250109">Claude 3.7 Sonnet</option>
+              <option value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet</option>
+              <option value="claude-3-5-haiku-20241022">Claude 3.5 Haiku</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Gemini設定 -->
+        <div id="gemini-config" class="provider-config" style="display: none;">
+          <div class="form-group">
+            <label for="gemini-apiKey">Gemini APIキー</label>
+            <input 
+              type="password" 
+              id="gemini-apiKey" 
+              class="form-input" 
+              placeholder="AIza..."
+            />
+            <p class="form-help">
+              <a href="https://makersuite.google.com/app/apikey" target="_blank" rel="noopener">APIキーの取得はこちら</a>
+            </p>
+          </div>
+          <div class="form-group">
+            <label for="gemini-model">モデル</label>
+            <select id="gemini-model" class="form-select">
+              <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
+              <option value="gemini-2.0-flash-exp">Gemini 2.0 Flash (Experimental)</option>
+              <option value="gemini-1.5-pro">Gemini 1.5 Pro</option>
+              <option value="gemini-1.5-flash">Gemini 1.5 Flash</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- OpenAI Compatible設定 -->
+        <div id="openai-compatible-config" class="provider-config" style="display: none;">
+          <div class="form-group">
+            <label for="compatible-baseUrl">ベースURL</label>
+            <input 
+              type="url" 
+              id="compatible-baseUrl" 
+              class="form-input" 
+              placeholder="https://api.example.com/v1"
+            />
+            <p class="form-help">OpenAI互換APIのベースURLを入力してください</p>
+          </div>
+          <div class="form-group">
+            <label for="compatible-apiKey">APIキー</label>
+            <input 
+              type="password" 
+              id="compatible-apiKey" 
+              class="form-input" 
+              placeholder="your-api-key"
+            />
+          </div>
+          <div class="form-group">
+            <label for="compatible-model">モデル名</label>
+            <input 
+              type="text" 
+              id="compatible-model" 
+              class="form-input" 
+              placeholder="model-name"
+            />
+            <p class="form-help">使用するモデル名を入力してください</p>
+          </div>
         </div>
       </section>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,10 +13,32 @@ export interface ReviewStepConfig {
 }
 
 /**
+ * AIプロバイダーの種類
+ */
+export type AIProvider = 'openai' | 'claude' | 'gemini' | 'openai-compatible';
+
+/**
+ * AIプロバイダー設定
+ */
+export interface AIProviderConfig {
+  readonly provider: AIProvider;
+  readonly apiKey: string;
+  readonly baseUrl?: string; // OpenAI Compatible用
+  readonly model?: string; // デフォルトモデル
+}
+
+/**
  * 拡張機能の設定
  */
 export interface ExtensionConfig {
-  readonly apiKey: string;
+  readonly selectedProvider: AIProvider;
+  readonly providers: {
+    readonly [K in AIProvider]: {
+      readonly apiKey: string;
+      readonly baseUrl?: string;
+      readonly model?: string;
+    };
+  };
   readonly reviewSteps: readonly ReviewStepConfig[];
 }
 


### PR DESCRIPTION
  ## What is the current behavior?

  - OpenAIのみに固定されたAI設定
  - 古いモデル選択肢（GPT-4、GPT-3.5-turbo等）
  - 単一プロバイダーの制限によりユーザーの選択肢が限定

  ## What is the new behavior?

  ### 🤖 複数AIプロバイダー対応
  - **4つのAIプロバイダーをサポート**: OpenAI、Claude (Anthropic)、Google Gemini、OpenAI
  Compatible
  - **プルダウン選択UI**: 直感的なプロバイダー切り替え
  - **個別設定管理**: 各プロバイダーのAPIキー・モデルを独立して管理
  - **動的UI表示**: 選択したプロバイダーの設定のみを表示

  ### 🔄 最新AIモデル対応
  **OpenAI**: GPT-4o (デフォルト)、O1、O1 Mini、GPT-4o Mini
  **Claude**: Claude 4 (Sonnet 4) (デフォルト)、Claude 3.7 Sonnet、Claude 3.5 Sonnet、Claude
  3.5 Haiku
  **Gemini**: Gemini 2.5 Flash (デフォルト)、Gemini 2.0 Flash (Experimental)、Gemini 1.5
  Pro、Gemini 1.5 Flash

  ### 🔒 強化されたバリデーション
  - **プロバイダー別APIキー検証**:
    - OpenAI: `sk-` 形式
    - Claude: `sk-ant-` 形式
    - Gemini: `AIza` 形式
    - OpenAI Compatible: 任意形式 + ベースURL・モデル名必須
  - **リアルタイムエラー表示**: 不正な設定を即座に検出

  ### 💾 改善されたデータ管理
  - **新設定形式**: プロバイダー別の構造化された設定保存
  - **自動マイグレーション**: 既存のOpenAI設定からスムーズに移行
  - **後方互換性**: 既存ユーザーの設定を保持

  ### 🎨 UI/UX向上
  - **プロバイダー設定ボックス**: 青いボーダーで視覚的に区別
  - **カスタムセレクトボックス**: 統一されたデザイン
  - **ダークモード完全対応**: 全新規要素でダークモード対応
  - **詳細フィードバック**: 保存時に選択プロバイダー情報を表示

  ### 🔧 技術的改善
  - **型安全性向上**: AIProvider型とExtensionConfig拡張
  - **設定の分離**: プロバイダー設定とレビューステップ設定の明確な分離
  - **エラーハンドリング**: プロバイダー固有のエラーメッセージ
