### PR TITLE
レビュー結果の永続化とSPA遷移対応機能を実装

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -128,6 +128,13 @@ class BackgroundService {
       const step3Result = results.find(result => result.step === 'step3');
       const finalResult = step3Result ? step3Result.content : 'レビューが完了しましたが、最終結果が生成されませんでした。';
 
+      // 表示結果をストレージに保存
+      try {
+        await StorageService.saveDisplayedResult(this.currentReviewId, finalResult);
+      } catch (error) {
+        console.error('表示結果の保存に失敗しました:', error);
+      }
+
       // 最終結果を表示
       this.notifyContentScript('REVIEW_COMPLETED', {
         reviewId: this.currentReviewId,

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -24,11 +24,27 @@ class ContentScript {
   /**
    * セットアップ処理
    */
-  private setup(): void {
+  private async setup(): Promise<void> {
     // PRページまたは差分ページの場合のみ処理を実行
     if (GitHubService.isPRPage() || GitHubService.isDiffPage()) {
       this.injectReviewButton();
       this.listenForMessages();
+      
+      // 保存されたレビュー結果を復元
+      await this.restoreReviewResults();
+    }
+  }
+
+  /**
+   * 保存されたレビュー結果を復元
+   */
+  private async restoreReviewResults(): Promise<void> {
+    try {
+      // DOM要素が準備されるまで少し待つ
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await GitHubService.restoreReviewResult();
+    } catch (error) {
+      console.error('レビュー結果の復元に失敗しました:', error);
     }
   }
 


### PR DESCRIPTION
## 概要

GitHubのプルリクエストページでAIレビュー結果が消失する問題を解決するため、レビュー結果の永続
化機能とSPA遷移対応機能を実装しました。

## 実装した機能

### 1. レビュー結果の永続化機能
- Chrome拡張機能のローカルストレージにレビュー結果を自動保存
- ページリロード時・ブラウザ再起動時に保存されたレビュー結果を自動復元
- レビュー結果のクローズボタンクリック時にストレージからも削除

### 2. ES Module Import エラーの修正
- Content scriptをIIFE形式でビルドしてモジュールエラーを解決
- Background scriptはES modules形式を維持
- Vite設定を2段階ビルドに分離（ES modules + IIFE）

### 3. SPA遷移対応機能
- MutationObserverを使用してGitHubのSPA遷移を監視
- ConversationタブとFile Changedタブ間の移動時に自動でレビュー結果を復元・再配置
- popstateイベント対応（ブラウザの戻る/進むボタン）

## 技術的な詳細

### ストレージ管理
- `StorageService`に表示済みレビュー結果の管理機能を追加
- `saveDisplayedResult()`, `getDisplayedResult()`, `clearDisplayedResult()` メソッド
- PR固有のキー生成（`${owner}-${repo}-${number}`）

### SPA遷移監視
- URLの変更を監視してページ遷移を検出
- DOM要素の安定化を待機してから復元処理を実行
- 表示対象コンテナの利用可能性チェック

### ビルド設定の改善
- Content script専用のIIFE形式ビルド（`content.iife.js`）
- その他のスクリプトはES modules形式を維持
- manifest.jsonでの適切なファイル参照

## テスト

- レビュー結果復元機能の包括的なテストケースを追加
- 保存・取得・削除の各機能をテスト
- エラーハンドリングのテスト

## 動作確認

- ✅ レビュー結果がページリロード後も表示される
- ✅ ConversationタブとFile Changedタブ間の移動で結果が維持される
- ✅ ブラウザ再起動後も保存された結果が復元される
- ✅ レビュー結果のクローズボタンで適切に削除される
- ✅ ES module import エラーが解決されレビューボタンが正常に表示される

## 破壊的変更

なし

## レビューポイント

- SPA遷移監視の実装方法とパフォーマンスへの影響
- ストレージキーの設計とデータ管理方法
- Content scriptのIIFE形式ビルドの適切性
- テストケースの網羅性

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>