### PR TITLE
feat: enhance reset functionality to clear all provider API keys and OpenAI Compatible fields

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -229,10 +229,20 @@ class OptionsController {
    */
   private resetToDefaults(): void {
     if (confirm('設定をデフォルトに戻しますか？')) {
-      // APIキーをクリア
-      if (this.apiKeyInput) {
-        this.apiKeyInput.value = '';
-      }
+      // 全プロバイダーのAPIキーをクリア
+      const apiKeyIds = ['openai-apiKey', 'claude-apiKey', 'gemini-apiKey', 'compatible-apiKey'];
+      apiKeyIds.forEach(id => {
+        const input = document.getElementById(id) as HTMLInputElement;
+        if (input) {
+          input.value = '';
+        }
+      });
+
+      // OpenAI Compatible特有のフィールドもクリア
+      const baseUrlInput = document.getElementById('compatible-baseUrl') as HTMLInputElement;
+      const modelInput = document.getElementById('compatible-model') as HTMLInputElement;
+      if (baseUrlInput) baseUrlInput.value = '';
+      if (modelInput) modelInput.value = '';
 
       // デフォルトプロンプトを設定
       this.setDefaultPrompts();
@@ -355,7 +365,9 @@ class OptionsController {
    * プロバイダー設定のバリデーション
    */
   private validateProviderConfig(provider: AIProvider): { isValid: boolean; error?: string } {
-    const apiKeyInput = document.getElementById(`${provider}-apiKey`) as HTMLInputElement;
+    // OpenAI Compatible用の特別なID処理
+    const apiKeyId = provider === 'openai-compatible' ? 'compatible-apiKey' : `${provider}-apiKey`;
+    const apiKeyInput = document.getElementById(apiKeyId) as HTMLInputElement;
     const apiKey = apiKeyInput?.value || '';
 
     if (!this.validateApiKey(provider, apiKey)) {


### PR DESCRIPTION
## What is the current behavior?
The reset functionality in the options page only clears the API key of the currently selected provider and doesn't handle OpenAI Compatible provider's specific fields (base URL and model). Additionally, there was an issue with provider validation not properly handling theOpenAI Compatible provider's unique ID mapping.

## What is the new behavior?
- The reset functionality now clears API keys for all supported providers (OpenAI, Claude,
Gemini, OpenAI Compatible) regardless of which provider is currently selected
- OpenAI Compatible specific fields (base URL and model) are properly cleared during reset
- Provider validation correctly handles the OpenAI Compatible provider's special ID mapping
(`compatible-apiKey` instead of `openai-compatible-apiKey`)